### PR TITLE
Add settings to change command visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,21 @@
                     "type": "string",
                     "default": "",
                     "description": "You can set terminal by default"
+                },
+                "open-native-terminal.show-current-folder-option": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Open terminal in current folder option is visible"
+                },
+                "open-native-terminal.show-root-folder-option": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Open terminal in root folder option is visible"
+                },
+                "open-native-terminal.show-terminal-icon": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Open terminal icon is visible in title bar"
                 }
             }
         },
@@ -67,41 +82,48 @@
             "commandPalette": [
                 {
                     "command": "extension.openNativeTerminal",
-                    "when": "editorHasSelection"
+                    "when": "editorHasSelection && config.open-native-terminal.show-current-folder-option"
                 },
                 {
                     "command": "extension.openNativeTerminalOnRootFolder",
-                    "when": "editorHasSelection"
+                    "when": "editorHasSelection && config.open-native-terminal.show-root-folder-option"
                 }
             ],
             "explorer/context": [
                 {
-                    "command": "extension.openNativeTerminal"
+                    "command": "extension.openNativeTerminal",
+                    "when": "config.open-native-terminal.show-current-folder-option"
                 },
                 {
-                    "command": "extension.openNativeTerminalOnRootFolder"
+                    "command": "extension.openNativeTerminalOnRootFolder",
+                    "when": "config.open-native-terminal.show-root-folder-option"
                 }
             ],
             "editor/context": [
                 {
-                    "command": "extension.openNativeTerminal"
+                    "command": "extension.openNativeTerminal",
+                    "when": "config.open-native-terminal.show-current-folder-option"
                 },
                 {
-                    "command": "extension.openNativeTerminalOnRootFolder"
+                    "command": "extension.openNativeTerminalOnRootFolder",
+                    "when": "config.open-native-terminal.show-root-folder-option"
                 }
             ],
             "editor/title": [
                 {
                     "command": "extension.openNativeTerminalOnRootFolder",
+                    "when": "config.open-native-terminal.show-terminal-icon",
                     "group": "navigation"
                 }
             ],
             "editor/title/context": [
                 {
-                    "command": "extension.openNativeTerminal"
+                    "command": "extension.openNativeTerminal",
+                    "when": "config.open-native-terminal.show-current-folder-option"
                 },
                 {
-                    "command": "extension.openNativeTerminalOnRootFolder"
+                    "command": "extension.openNativeTerminalOnRootFolder",
+                    "when": "config.open-native-terminal.show-root-folder-option"
                 }
             ]
         }


### PR DESCRIPTION
This allows the user to toggle the visibility of the icon on the title bar, the current folder terminal launch command and the root folder terminal launch command. 

This is a feature that I personally would totally use and I am sure it would come in handy.

Pretty straightforward, should just need to change version number. Let me know if I can do anything else!